### PR TITLE
Loosen `requests` requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ certifi==2018.1.18
 chardet==3.0.4
 future==0.16.0
 idna==2.6
-requests==2.20.0
+requests>=2.20.0
 urllib3==1.26.5


### PR DESCRIPTION
As specified, the new version for `urllib3` conflicts with a version dependency in `requests 2.20.0`. This resolves that dependency conflict; however, I don't know if/why you had `requests` at that specific version; if some additional reason, this change may be incorrect.